### PR TITLE
Rolled back to gradle 6.7.1 and AGP4.2.2 for java-8 cross compat

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 android {
     compileSdk 30
-
     defaultConfig {
         applicationId "com.example.androidmodule"
         minSdk 21
@@ -22,8 +21,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     configurations.all {
         exclude group:"org.jmonkeyengine",module:"jme3-desktop"

--- a/app/src/main/java/com/example/androidmodule/AndroidLauncher.java
+++ b/app/src/main/java/com/example/androidmodule/AndroidLauncher.java
@@ -1,19 +1,17 @@
 package com.example.androidmodule;
 
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.view.View;
-
-import com.google.android.material.snackbar.BaseTransientBottomBar;
-import com.google.android.material.snackbar.Snackbar;
+import android.widget.Toast;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import com.jme3.app.LegacyApplication;
 import com.jme3.app.jmeSurfaceView.JmeSurfaceView;
 import com.jme3.app.jmeSurfaceView.OnExceptionThrown;
 import com.jme3.app.jmeSurfaceView.OnRendererCompleted;
-import myGame.Game;
 import com.jme3.system.AppSettings;
+import myGame.Game;
 
 /**
  * Used to create an Android Activity, the main entry for {@link android.view.Choreographer} to render Ui-Components.
@@ -57,7 +55,7 @@ public class AndroidLauncher extends AppCompatActivity implements OnRendererComp
         //test android views (native android Ui -- managed by Choreographer)
         final View button = findViewById(R.id.button);
         //invoking the call from the android context aka from the Choreographer thread not gl thread  :-))
-        button.setOnClickListener((view)-> Snackbar.make(view, "Android View OnClick invoked", BaseTransientBottomBar.LENGTH_SHORT).show());
+        button.setOnClickListener((view)-> Toast.makeText(getApplicationContext(), "Android View OnClick invoked", Toast.LENGTH_LONG).show());
         //shallow copying the surface view to be managed by the life cycle
         this.jmeSurfaceView = gl_surfaceView;
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,25 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    // define android system repositories
     repositories {
         google()
         mavenCentral()
-        jcenter()
-        maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.3"
+        classpath "com.android.tools.build:gradle:4.2.2"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
-
 }
-
+// all modules repos
+allprojects {
+    repositories {
+        google()
+        jcenter()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
+}
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/desktop/src/main/java/com/example/desktopmodule/DesktopLauncher.java
+++ b/desktop/src/main/java/com/example/desktopmodule/DesktopLauncher.java
@@ -1,7 +1,7 @@
 package com.example.desktopmodule;
 
-import myGame.Game;
 import com.jme3.system.AppSettings;
+import myGame.Game;
 
 /**
  * Used to launch a jme application in desktop environment using native GLFW.

--- a/game/build.gradle
+++ b/game/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 24 21:43:27 CDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,3 @@
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
-    }
-}
 rootProject.name = "CrossPlatformModule"
 include ':app'
 include ':desktop'


### PR DESCRIPTION
This commit includes : 

- Rolling back to gradle 6.7.1 using android studio 4.2.0.
- Rolling back to AGP-4.2.2.
- Project clean-up.